### PR TITLE
chore: some linter based cleanup

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,6 @@ html_theme_options = {
 }
 html_logo = "./logo.svg"
 html_favicon = "./logo.svg"
-html_title = f'{project}'
+html_title = project
 nbsphinx_timeout = 300
 suppress_warnings = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,4 @@
-import os
-import sys
 import datetime
-from importlib import import_module
-
 
 # -- Project information -----------------------------------------------------
 
@@ -31,10 +27,10 @@ html_theme_options = {
     "use_issues_button": True,
     "use_edit_page_button": True,
     "show_toc_level": 3,
-    'default_mode': 'dark',  
+    'default_mode': 'dark',
 }
 html_logo = "./logo.svg"
 html_favicon = "./logo.svg"
-html_title = '{0}'.format(project)
+html_title = f'{project}'
 nbsphinx_timeout = 300
 suppress_warnings = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import datetime
 
 project = "peytonites"
 author = "peytonites"
-copyright = '{0}, {1}'.format(datetime.datetime.now().year, "peytonites")
+copyright = '{}, {}'.format(datetime.datetime.now().year, "peytonites")
 package = "peytonites"
 
 # -- General configuration ---------------------------------------------------

--- a/hackathon/main.py
+++ b/hackathon/main.py
@@ -61,7 +61,7 @@ def simulation(sim_init_cond, out_dir, verbose=True):
                 step_params = sim_init_cond.copy()
                 step_params.distribution = step_dist
 
-            step_filename = 'step_{:08d}.dat'.format(step)
+            step_filename = f'step_{step:08d}.dat'
             step_path = os.path.join(out_dir, step_filename)
             if not os.path.isdir(out_dir):
                 os.makedirs(out_dir)
@@ -69,14 +69,13 @@ def simulation(sim_init_cond, out_dir, verbose=True):
 
     if verbose:
         print(step)
-    return
 
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:
         print("Usage: python main.py <path_to_initial_conditions> <path_to_output_dir>")
         sys.exit(1)
-    
+
     init_cond_path = sys.argv[1]
     out_dir = sys.argv[2]
 

--- a/peytonites/_astropy_init.py
+++ b/peytonites/_astropy_init.py
@@ -10,4 +10,5 @@ except ImportError:
 
 # Create the test function for self test
 from astropy.tests.runner import TestRunner
+
 test = TestRunner.make_test_runner_in(os.path.dirname(__file__))

--- a/peytonites/core.py
+++ b/peytonites/core.py
@@ -1,10 +1,9 @@
-from os import path 
-
-import numpy as np
-
-from astropy import units as u
+from os import path
 
 import matplotlib.pyplot as plt
+import numpy as np
+from astropy import units as u
+
 plt.rcParams['figure.figsize'] = [6, 6]
 plt.rcParams['image.origin'] = 'lower'
 plt.rcParams['font.size'] = 12
@@ -46,9 +45,9 @@ class SimState:
 
     @staticmethod
     def read(filename):
-        with open(filename, "r") as f:
+        with open(filename) as f:
             line = f.readline().replace('\n', '').split(' ')
-            N, nsteps, dt, soft, out_interval, G_in = [float(i) for i in line]
+            N, nsteps, dt, soft, out_interval, G_in = (float(i) for i in line)
             nsteps = int(nsteps)
             out_interval = int(out_interval)
             points = []
@@ -59,10 +58,10 @@ class SimState:
         sim_init_cond = SimState(dist, nsteps, dt, soft, out_interval)
         sim_init_cond.G = G_in
         return sim_init_cond
-    
+
     def copy(self):
         return SimState(
-            self.distribution, self.nsteps, self.dt, 
+            self.distribution, self.nsteps, self.dt,
             self.soft, self.out_interval)
 
 
@@ -85,7 +84,7 @@ class Distribution:
         self.name = name
 
         self._points = points
-        self.points = np.array(self._points, float) 
+        self.points = np.array(self._points, float)
         self.points_T = self.points.T
         self.N = len(self.points)
 
@@ -93,22 +92,22 @@ class Distribution:
 
 
     def __str__(self):
-        return 'Points: {}, Distribution: {}'.format(len(self.points), self.name)
+        return f'Points: {len(self.points)}, Distribution: {self.name}'
 
 
     def __add__(self, other):
         '''Combine two Distribution points'''
         if not isinstance(other, Distribution):
             raise TypeError('You can only sum Distribution to another Distribution')
-        
+
         if self.name and other.name:
-            name = self.name + '+' + other.name 
+            name = self.name + '+' + other.name
         else:
             name = self.name if self.name else other.name
 
         return Distribution(self._points +  other._points, name)
-    
-    
+
+
     def _write_lines(self, f):
         for line in self.points:
                 line = " ".join([str(j) for j in line])
@@ -125,7 +124,7 @@ class Distribution:
 
     @staticmethod
     def read(filename):
-        with open(filename, "r") as f:
+        with open(filename) as f:
             points = []
             for line in f:
                 points.append(line.split(' '))
@@ -146,7 +145,7 @@ class Distribution:
         coordinates = [(x, y), (x, z), (y, z)]
         labels = [('X', 'Y'), ('X', 'Z'), ('Y', 'Z')]
 
-        for ax, (data_x, data_y), (label_x, label_y) in zip(axs, coordinates, labels):
+        for ax, (data_x, data_y), (label_x, label_y) in zip(axs, coordinates, labels, strict=False):
             plt.sca(ax)
             plt.scatter(data_x, data_y)
             plt.xlabel(f'{label_x} [{unit}]')
@@ -158,12 +157,12 @@ class Distribution:
 
     @staticmethod
     def from_arrays(
-        x_arr, y_arr, z_arr, 
+        x_arr, y_arr, z_arr,
         vx_arr, vy_arr, vz_arr,
         mass_arr, name=''):
 
         points = np.array([
-            x_arr, y_arr, z_arr, 
+            x_arr, y_arr, z_arr,
             vx_arr, vy_arr, vz_arr,
             mass_arr
         ]).T

--- a/peytonites/core.py
+++ b/peytonites/core.py
@@ -9,8 +9,10 @@ plt.rcParams['image.origin'] = 'lower'
 plt.rcParams['font.size'] = 12
 
 __all__ = [
-    'SimState', 'Distribution',
-    'dynamical_time', 'estimate_softening_length'
+    'Distribution',
+    'SimState',
+    'dynamical_time',
+    'estimate_softening_length'
 ]
 
 
@@ -103,15 +105,15 @@ class Distribution:
         if self.name and other.name:
             name = self.name + '+' + other.name
         else:
-            name = self.name if self.name else other.name
+            name = self.name or other.name
 
         return Distribution(self._points +  other._points, name)
 
 
     def _write_lines(self, f):
         for line in self.points:
-                line = " ".join([str(j) for j in line])
-                f.write(line+"\n")
+            line_s = " ".join([str(j) for j in line])
+            f.write(f"{line_s}\n")
 
     def _write_init_file(self, filename, nsteps, dt, soft, out_interval, G_out):
         with open(filename, "w") as f:
@@ -125,9 +127,7 @@ class Distribution:
     @staticmethod
     def read(filename):
         with open(filename) as f:
-            points = []
-            for line in f:
-                points.append(line.split(' '))
+            points = [line.split(' ') for line in f]
         basename = path.splitext(filename)[0]
         return Distribution(points, name=basename)
 
@@ -182,6 +182,4 @@ def estimate_softening_length(N, radius, fraction=0.1):
 
     mean_interparticle_distance = (1 / number_density) ** (1/3)
 
-    softening_length = fraction * mean_interparticle_distance
-
-    return softening_length
+    return fraction * mean_interparticle_distance

--- a/peytonites/dist.py
+++ b/peytonites/dist.py
@@ -5,7 +5,10 @@ import numpy as np
 from .core import Distribution, G
 
 __all__ = [
-    'solar_system', 'disk', 'collapse_shpere', 'plummer',
+    'collapse_shpere',
+    'disk',
+    'plummer',
+    'solar_system',
 ]
 
 def solar_system():
@@ -54,7 +57,7 @@ def disk(
     mass = disk_mass / N
     dens = N / (radius * radius)
     r_list = []
-    for i in range(N):
+    for _ in range(N):
         r = rn.uniform(0.0, radius) + 4e3
         thet = rn.uniform(0.0000001, 2.0 * np.pi) #+ phi0
 
@@ -90,7 +93,7 @@ def collapse_shpere(N, radius,
                     vx=0., vy=0., vz=0.):
     points = []
 
-    for i in range(N):
+    for _ in range(N):
         r = rn.uniform(0.0, radius)
         phi = rn.uniform(0.0000001, 2.0 * np.pi)
         costheta = rn.uniform(-1,1)
@@ -136,7 +139,7 @@ def plummer(N, radius,
     M = total_mass
     mass = M/N
 
-    for i in range(N):
+    for _ in range(N):
         r = None
         while r is None or r > max_radius:
             uni_draw = np.random.uniform(0, 1)

--- a/peytonites/dist.py
+++ b/peytonites/dist.py
@@ -1,21 +1,21 @@
+import random as rn
+
 import numpy as np
-import random as rn 
 
 from .core import Distribution, G
 
-
 __all__ = [
-    'solar_system', 'disk', 'collapse_shpere', 'plummer', 
+    'solar_system', 'disk', 'collapse_shpere', 'plummer',
 ]
 
 def solar_system():
     M_sun = 1.988e+33 # in grams
-    masses = np.array([M_sun, 3.300e+26, 4.870e+27, 
-                       5.970e+27, 6.420e+26, 1.898e+30, 
+    masses = np.array([M_sun, 3.300e+26, 4.870e+27,
+                       5.970e+27, 6.420e+26, 1.898e+30,
                        5.680e+29, 8.680e+28, 1.020e+29]) # in grams
 
-    r_dist = np.array([0., 5.790e+12, 1.082e+13, 
-                       1.496e+13, 2.279e+13, 7.785e+13, 
+    r_dist = np.array([0., 5.790e+12, 1.082e+13,
+                       1.496e+13, 2.279e+13, 7.785e+13,
                        1.434e+14, 2.871e+14, 4.495e+14]) # in cm
 
     x_arr = r_dist.copy()
@@ -28,9 +28,9 @@ def solar_system():
     vx_arr = np.zeros_like(r_dist)
     vy_arr = v_kep.copy()
     vz_arr = np.zeros_like(r_dist)
-    
+
     return Distribution.from_arrays(
-        x_arr, y_arr, z_arr, 
+        x_arr, y_arr, z_arr,
         vx_arr, vy_arr, vz_arr,
         masses, name='Solar')
 
@@ -67,7 +67,7 @@ def disk(
         z = (-(a * x) - (b * y)) / c
 
         m0 = 0 #len(np.where(np.array(r_list) < r)[0]) * mass
-        v = 1 * np.sqrt(((G * (main_mass + m0)) / r))  # / np.sqrt(2)
+        v = 1 * np.sqrt((G * (main_mass + m0)) / r)  # / np.sqrt(2)
 
         vi = v * -np.sin(thet)
         vj = v * np.cos(thet)
@@ -125,7 +125,7 @@ def scalar_to_sph(r, thet=None, phi=None):
 
 def plummer(N, radius,
             x0, y0, z0, total_mass,
-            vx0=0., vy0=0., vz0=0, 
+            vx0=0., vy0=0., vz0=0,
             max_radius=np.inf):
 
     points = []

--- a/peytonites/plot.py
+++ b/peytonites/plot.py
@@ -1,20 +1,16 @@
-from os import path 
-import re 
+import re
 from glob import glob
-
-import numpy as np 
-
-from astropy import units as u 
-from astropy import constants as const 
+from os import path
 
 import matplotlib.pyplot as plt
+import numpy as np
+from astropy import units as u
 from matplotlib.animation import FuncAnimation, PillowWriter
 
 from .core import SimState
 
-
 __all__ = [
-    'simulation_to_gif_2d', 'simulation_to_gif_3d', 
+    'simulation_to_gif_2d', 'simulation_to_gif_3d',
 ]
 
 
@@ -25,15 +21,15 @@ def natural_sort(l):
 
 
 
-def simulation_to_gif_3d(simulation_dir, gif_filename='simulation_3d.gif', 
+def simulation_to_gif_3d(simulation_dir, gif_filename='simulation_3d.gif',
                          scale=1, alpha=1., unit='cm', extent=None, fps=25):
-    
+
     gif_path = path.join(simulation_dir, gif_filename)
     fb = natural_sort(glob(path.join(simulation_dir, '*step*.dat')))
-    
+
     if len(fb) < 1:
-        return 
-    
+        return
+
     init_cond = SimState.read(fb[0]).distribution.points
     init_cond = np.array(init_cond, float)
     x_arr, y_arr, z_arr, vx_arr ,vy_arr ,vz_arr, masses = init_cond.T
@@ -42,17 +38,17 @@ def simulation_to_gif_3d(simulation_dir, gif_filename='simulation_3d.gif',
     init_xmax = abs(x_arr).max()*scale
     init_ymax = abs(y_arr).max()*scale
     init_zmax = abs(z_arr).max()*scale
-    
+
     fig = plt.figure()
     axs = fig.add_subplot(111, projection='3d')
-    
+
     def animate(i):
         axs.clear()
-        
+
         max_range = max([init_xmax, init_ymax, init_zmax])
         if extent is not None:
             max_range = extent.to(unit).value if isinstance(extent, u.Quantity) else extent
-            
+
         axs.set_xlim(-max_range, max_range)
         axs.set_ylim(-max_range, max_range)
         axs.set_zlim(-max_range, max_range)
@@ -61,30 +57,30 @@ def simulation_to_gif_3d(simulation_dir, gif_filename='simulation_3d.gif',
         # axs.w_xaxis.set_pane_color((w_axis_value, w_axis_value, w_axis_value, 1.0))
         # axs.w_yaxis.set_pane_color((w_axis_value, w_axis_value, w_axis_value, 1.0))
         # axs.w_zaxis.set_pane_color((w_axis_value, w_axis_value, w_axis_value, 1.0))
-        
+
         f = fb[i]
         dist = SimState.read(f).distribution
-        
+
         x = (dist.x * u.cm).to(unit).value
         y = (dist.y * u.cm).to(unit).value
         z = (dist.z * u.cm).to(unit).value
-        
+
         scatter1 = axs.scatter3D(x, y, z, alpha=alpha, color='black')
         return [scatter1]
-    ani = FuncAnimation(fig, animate, interval=1, blit=True, repeat=True, frames=len(fb))    
+    ani = FuncAnimation(fig, animate, interval=1, blit=True, repeat=True, frames=len(fb))
     ani.save(gif_path, dpi=100, writer=PillowWriter(fps=fps))
     plt.show()
 
 
-def simulation_to_gif_2d(simulation_dir, gif_filename='simulation_2d.gif', 
+def simulation_to_gif_2d(simulation_dir, gif_filename='simulation_2d.gif',
                          scale=1., alpha=1., unit='cm', extent=None, fps=25):
-    
+
     gif_path = path.join(simulation_dir, gif_filename)
     fb = natural_sort(glob(path.join(simulation_dir, '*step*.dat')))
-    
+
     if len(fb) < 1:
-        return 
-    
+        return
+
     init_cond = SimState.read(fb[0]).distribution.points
     init_cond = np.array(init_cond, float)
     x_arr, y_arr, z_arr, vx_arr, vy_arr, vz_arr, masses = init_cond.T
@@ -93,16 +89,16 @@ def simulation_to_gif_2d(simulation_dir, gif_filename='simulation_2d.gif',
     init_xmax = abs(x_arr).max() * scale
     init_ymax = abs(y_arr).max() * scale
     init_zmax = abs(z_arr).max() * scale
-    
+
     fig, axs = plt.subplots(1, 2, figsize=(12, 6))
-    
+
     def animate(i):
         axs[0].clear()
         axs[1].clear()
-        
+
         f = fb[i]
         dist = SimState.read(f).distribution
-        
+
         x = (dist.x * u.cm).to(unit).value
         y = (dist.y * u.cm).to(unit).value
         z = (dist.z * u.cm).to(unit).value
@@ -113,9 +109,9 @@ def simulation_to_gif_2d(simulation_dir, gif_filename='simulation_2d.gif',
         max_range = max([init_xmax, init_ymax, init_zmax])
         if extent is not None:
             max_range = extent.to(unit).value if isinstance(extent, u.Quantity) else extent
-        
+
         scatter_list = []
-        for ax, (data_x, data_y), (label_x, label_y) in zip(axs, coordinates, labels):
+        for ax, (data_x, data_y), (label_x, label_y) in zip(axs, coordinates, labels, strict=False):
             scatter = ax.scatter(data_x, data_y, alpha=alpha, color='black')
             ax.set_xlabel(f'{label_x} [{unit}]')
             ax.set_ylabel(f'{label_y} [{unit}]')

--- a/peytonites/utils.py
+++ b/peytonites/utils.py
@@ -1,5 +1,6 @@
 from astropy import units as u
 
+
 def kpc_to_cm(value):
     return (value * u.kpc).to(u.cm).value
 


### PR DESCRIPTION
Tried running `hatch fmt`, and applied most of the fixes. (I don't agree with all of it's default checks, but it's customizable and I could set it up in the future). Then manually ran `ruff check .` with some different `--select` rules to find a few more things for easy cleanup. Not going all out adding https://learn.scientific-python.org/development/guides/style/ and enforcing anything but this looked like easy cleanup.


- **style: some touch up from hatch fmt**
- **chore: some more manual fixes from running ruff**
